### PR TITLE
chore: seed agent suggestions (vote API, features page, schema note, README)

### DIFF
--- a/.ai/roadmap/new.md
+++ b/.ai/roadmap/new.md
@@ -1,6 +1,7 @@
 # Suggestions (auto-generated)
 S-100: Add /api/health — ensure uptime endpoint for monitoring.
 S-101: Create Supabase features table note — unblock listing.
-S-102: Implement /api/vote (POST) — increments votes.
-S-103: Create minimal features list page — title + votes.
-S-104: README: setup, envs, deploy steps.
+S-102: Implement /api/vote (POST) — increments a feature’s votes.
+S-103: Create minimal /features page — list title + votes.
+S-104: Supabase schema note for features — id, title, votes (int default 0).
+S-105: README: setup envs + local run + deploy steps.

--- a/.github/workflows/ai-loop.yml
+++ b/.github/workflows/ai-loop.yml
@@ -29,7 +29,7 @@ jobs:
           git config --global user.email "agent@basstian-ai.com"
 
       - name: Run ai-dev-agent (full loop)
-        uses: basstian-ai/ai-dev-agent@v1.0.5  # <-- pin to your new tag
+        uses: basstian-ai/ai-dev-agent@v1.0.6  # <-- pin to your new tag
         with:
           config: ${{ vars.AGENT_CONFIG_PATH || '.ai/agent.yml' }}
           max-diff-lines: ${{ vars.AGENT_MAX_DIFF_LINES || '400' }}


### PR DESCRIPTION
## Summary
- seed roadmap with vote API, features page, schema note, and README tasks
- bump ai-dev-agent workflow tag to v1.0.6

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8f622df00832aaa1f4165f65dec93